### PR TITLE
add event listener on switch wallet

### DIFF
--- a/lib/components/ConnectWallet/index.vue
+++ b/lib/components/ConnectWallet/index.vue
@@ -10,6 +10,7 @@ import {
 } from '../../../lib/wallet/Wallet';
 import { readWallet } from '../../../lib/wallet/Wallet';
 import { Icon } from '@iconify/vue';
+import { onMounted, onUnmounted } from 'vue';
 
 const props = defineProps({
     chainId: String,
@@ -42,6 +43,13 @@ const list = [
         logo: 'https://ping.pub/logos/metamask.png',
     }
 ];
+
+onMounted(() => {
+  window.addEventListener("keplr_keystorechange", connect)
+})
+onUnmounted(() => {
+  window.removeEventListener('keplr_keystorechange', connect)
+})
 
 async function initData() { }
 


### PR DESCRIPTION
The account login localstorage is set from this repo. It will be better to fix it here than the `NavBarWallet.vue` at explorer repo.


close https://github.com/ping-pub/explorer/issues/523 
ref: https://docs.keplr.app/api/#change-key-store-event